### PR TITLE
Optimizing Docker installation and changing default web server to Caddy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,20 @@
-FROM node:lts-stretch
+FROM node:14-slim as builder
+RUN apt-get update && apt-get install -y jq curl wget python
 WORKDIR /app
-ADD . .
-RUN yarn ; yarn build
 
-FROM nginx:stable
-WORKDIR /app
-COPY --from=0 /app/build /usr/share/nginx/html
+### Get the latest release source code tarball
+RUN tarball_url=$(curl -s https://api.github.com/repos/troyeguo/koodo-reader/releases/latest | jq -r ".tarball_url") \
+    && wget -qO- $tarball_url \
+    | tar xvfz - --strip 1
+
+### --network-timeout 1000000 as a workaround for slow devices
+### when the package being installed is too large, Yarn assumes it's a network problem and throws an error
+RUN yarn --network-timeout 1000000
+
+### Separate `yarn build` layer as a workaround for devices with low RAM.
+### If build fails due to OOM, `yarn install` layer will be already cached.
+RUN yarn build
+
+### Nginx or Apache can also be used, Caddy is just smaller in size
+FROM caddy:latest
+COPY --from=builder /app/build /usr/share/caddy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
-version: "3"
+version: '3.5'
 services:
   koodo:
-    build: .
+    container_name: koodo
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
-      - "80:80"
+      - "80:80/tcp"
+    restart: unless-stopped


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Docker installation now builds images from the source code of the latest release. There is no need to clone the repository.  Installing Koodo-reader using Docker requires two files: _Dockerfile_ and _docker-compose.yaml_.

Optimizations: 

- _node:14-slim_ image (~60 MB) is used as builder vs the previously used _node:lts-stretch_ (~340 MB);
- added `--network-timeout 1000000` parameter to `yarn install` command to avoid errors on slow devices, when the package being installed is too large and Yarn assumes it's a network problem ([for reference](https://stackoverflow.com/questions/51508364/yarn-there-appears-to-be-trouble-with-your-network-connection-retrying));
- `yarn build` was moved to a separate layer from `yarn install` to avoid repeated `yarn install` step if, for some reason, the build fails, e.g. due to OOM on devices with little RAM;
- The webserver was changed from Nginx to Caddy, which significantly reduced the size of the final image (bare _nginx:stable_ ~50 MB vs _caddy:latest_ ~13 MB). The final image with the webserver and koodo-reader inside is now ~63 MB, as opposed to Nginx installation which was ~165 MB.


## Related Issues

No related issues at the moment. The goal of this PR is to optimize Docker installation method and make it work on slow devices.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
