### PR TITLE
Fix docker compilation failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:14-slim as builder
-RUN apt-get update && apt-get install -y jq curl wget python
+FROM node:18-slim as builder
+RUN apt-get update && apt-get install -y jq curl wget python3
 WORKDIR /app
 
 ### Get the latest release source code tarball
@@ -13,7 +13,8 @@ RUN yarn --network-timeout 1000000
 
 ### Separate `yarn build` layer as a workaround for devices with low RAM.
 ### If build fails due to OOM, `yarn install` layer will be already cached.
-RUN yarn build
+RUN yarn \
+    && yarn build
 
 ### Nginx or Apache can also be used, Caddy is just smaller in size
 FROM caddy:latest


### PR DESCRIPTION

## Description
Fix compilation error
## Related Issues
1. node 14 is not compatiable with node 18
2. package `python` is not found in `node18`. install `python3` instead
3. `react-script` is missing during build. So run `yarn` to install dependencies before build

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
