### PR TITLE
fix(httpServer): restrict CORS to allow-listed origins (CWE-942)

### DIFF
--- a/httpServer.js
+++ b/httpServer.js
@@ -94,13 +94,28 @@ function applyCorsHeaders(req, res) {
   return false;
 }
 
+// 计算请求的有效服务端 Origin，用于判断 Origin 头是否表示同源请求。
+// 浏览器在同源的 POST/DELETE/fetch 请求中也会发送 Origin 头，
+// 因此不能仅凭 Origin 头存在就将其视为跨域请求。
+function getServerOrigin(req) {
+  const host = req.headers["host"];
+  if (!host) return null;
+  const scheme =
+    req.socket && req.socket.encrypted
+      ? "https"
+      : (req.headers["x-forwarded-proto"] || "http").split(",")[0].trim();
+  return `${scheme}://${host}`;
+}
+
 const server = http.createServer((req, res) => {
   const origin = req.headers["origin"];
+  const serverOrigin = getServerOrigin(req);
+  const isCrossOrigin = !!origin && origin !== serverOrigin;
   const corsAllowed = applyCorsHeaders(req, res);
 
   // 处理预检请求
   if (req.method === "OPTIONS") {
-    if (origin && !corsAllowed) {
+    if (isCrossOrigin && !corsAllowed) {
       res.writeHead(403, { "Content-Type": "text/plain" });
       return res.end("Origin not allowed");
     }
@@ -108,9 +123,10 @@ const server = http.createServer((req, res) => {
     return res.end();
   }
 
-  // 对于带 Origin 的实际请求，若不在白名单则拒绝，
+  // 对于跨域的实际请求，若来源不在白名单则拒绝，
   // 防止凭据被跨站请求滥用 (CSRF / CWE-942)。
-  if (origin && !corsAllowed) {
+  // 同源请求（包括带 Origin 头的 POST/DELETE）允许通过。
+  if (isCrossOrigin && !corsAllowed) {
     res.writeHead(403, { "Content-Type": "text/plain" });
     return res.end("Origin not allowed");
   }

--- a/httpServer.js
+++ b/httpServer.js
@@ -31,6 +31,14 @@ const VALID_CREDENTIALS = {
   password: SERVER_PASSWORD,
 };
 
+// CORS 允许的来源列表（逗号分隔）。默认不允许任何跨域来源，
+// 仅允许同源（无 Origin 头）请求，以避免 CSRF/凭据滥用。
+// 例如：ALLOWED_ORIGINS="https://reader.example.com,https://app.example.com"
+const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS || "")
+  .split(",")
+  .map((o) => o.trim())
+  .filter((o) => o.length > 0);
+
 // 验证密码来源
 if (getDockerSecret(SERVER_PASSWORD_FILE)) {
   console.info("Using password from Docker Secret");
@@ -48,6 +56,13 @@ if (!process.env.SERVER_USERNAME) {
   );
 }
 
+if (ALLOWED_ORIGINS.length === 0) {
+  console.warn(
+    "Warning: No ALLOWED_ORIGINS configured. Cross-origin requests will be denied. " +
+      "Set ALLOWED_ORIGINS to a comma-separated list of trusted origins if needed."
+  );
+}
+
 // 检查服务器是否启用
 if (!SERVER_ENABLED) {
   console.info(
@@ -61,18 +76,45 @@ if (!fs.existsSync(UPLOAD_DIR)) {
   fs.mkdirSync(UPLOAD_DIR, { recursive: true });
 }
 
-const server = http.createServer((req, res) => {
-  // 设置CORS头部
-  res.setHeader("Access-Control-Allow-Origin", "*");
+// 设置安全的 CORS 头部：
+// - 仅当请求 Origin 在白名单中时回显该 Origin，并允许凭据
+// - 否则不发送 ACAO 头，浏览器会阻止跨域响应读取
+// 永远不会同时使用通配符 "*" 与 Allow-Credentials: true。
+function applyCorsHeaders(req, res) {
+  const origin = req.headers["origin"];
+  res.setHeader("Vary", "Origin");
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  res.setHeader("Access-Control-Allow-Credentials", "true");
+
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Access-Control-Allow-Credentials", "true");
+    return true;
+  }
+  return false;
+}
+
+const server = http.createServer((req, res) => {
+  const origin = req.headers["origin"];
+  const corsAllowed = applyCorsHeaders(req, res);
 
   // 处理预检请求
   if (req.method === "OPTIONS") {
-    res.writeHead(200);
+    if (origin && !corsAllowed) {
+      res.writeHead(403, { "Content-Type": "text/plain" });
+      return res.end("Origin not allowed");
+    }
+    res.writeHead(204);
     return res.end();
   }
+
+  // 对于带 Origin 的实际请求，若不在白名单则拒绝，
+  // 防止凭据被跨站请求滥用 (CSRF / CWE-942)。
+  if (origin && !corsAllowed) {
+    res.writeHead(403, { "Content-Type": "text/plain" });
+    return res.end("Origin not allowed");
+  }
+
   // 认证检查
   if (!authenticate(req)) {
     res.writeHead(401, {


### PR DESCRIPTION
## Summary

Harden the optional HTTP server's CORS configuration in `httpServer.js`. The previous configuration sent `Access-Control-Allow-Origin: *` together with `Access-Control-Allow-Credentials: true` for every request. This is a CWE-942 (Permissive Cross-domain Policy with Untrusted Domains) misconfiguration: it advertises that any origin may interact with the server, and pairs that wildcard with a credentials flag.

- **CWE:** [CWE-942 — Permissive Cross-domain Policy with Untrusted Domains](https://cwe.mitre.org/data/definitions/942.html)
- **File:** `httpServer.js` (the `http.createServer` request handler)
- **Severity:** Medium — the server is opt-in (`ENABLE_HTTP_SERVER=true`) and gated by HTTP Basic auth, which limits practical impact, but the permissive policy is still a hardening issue worth fixing.

## Fix

Replace the wildcard CORS policy with an explicit allow-list driven by a new `ALLOWED_ORIGINS` environment variable (comma-separated):

- If a request's `Origin` header matches an entry in `ALLOWED_ORIGINS`, the server echoes that exact origin in `Access-Control-Allow-Origin` and sets `Access-Control-Allow-Credentials: true`.
- If a request carries an `Origin` that is not on the allow-list, the server responds with `403 Origin not allowed` for both preflight (`OPTIONS`) and actual requests, so credentials cannot be replayed cross-site.
- Same-origin requests (no `Origin` header) continue to work unchanged.
- `Vary: Origin` is always set so caches don't serve the wrong CORS response across origins.
- The wildcard `*` is never combined with `Allow-Credentials: true`.
- A startup warning is logged if `ALLOWED_ORIGINS` is empty, so operators who actually need cross-origin access notice it.

The default (empty allow-list) is safe: cross-origin browsers cannot read responses or invoke state-changing requests with credentials. Operators that need cross-origin access opt in explicitly.

## What I tested

- Reviewed the only CORS site in the file — there is a single request handler, no parallel paths that could re-introduce the wildcard.
- Walked through the three relevant request shapes manually:
  1. Same-origin request (no `Origin` header) → no CORS headers, normal auth flow runs.
  2. Allowed cross-origin request (`Origin` in `ALLOWED_ORIGINS`) → `ACAO: <origin>`, `ACAC: true`, request proceeds.
  3. Disallowed cross-origin request → `403` for both `OPTIONS` and other methods, no `ACAO` echoed.
- Confirmed `Vary: Origin` is set on every response so shared caches won't leak a permitted origin's response to another origin.
- Confirmed the change is backward compatible for the documented usage (server reached on the same host:port the user configured).

## Security analysis

The pre-fix handler did this for every request:

```js
res.setHeader("Access-Control-Allow-Origin", "*");
res.setHeader("Access-Control-Allow-Credentials", "true");
```

Two concrete concerns:

1. **Permissive cross-origin reads.** Any web page a user visits could issue `fetch()` requests to the local Koodo Reader HTTP server and, for any non-credentialed response the server returns (errors, future unauthenticated endpoints, metadata), read the body cross-origin. Today every authenticated endpoint returns `401` to an unauthenticated cross-origin caller, which limits the blast radius — but the permissive header is a footgun for any future endpoint added without explicit auth.
2. **Credentials advertisement.** Sending `Allow-Credentials: true` with a wildcard origin is malformed per the Fetch spec, so browsers reject the credentialed read in practice. That's a browser-side mitigation, not a server-side one — relying on it leaves the server one config change (or one non-browser client) away from leaking auth-protected responses cross-site.

Preconditions for any real-world exploitation of the original behaviour:

- `ENABLE_HTTP_SERVER=true` must be set (the feature is opt-in).
- The victim must visit an attacker-controlled page while the server is reachable from their browser.
- For credentialed exfiltration, the browser must honor `*` + credentials (current browsers don't), so this path is effectively blocked today.
- For non-credentialed reads, the attacker can only read responses the server returns without requiring auth — currently none, but the wildcard makes that fragile.

The fix removes the wildcard entirely and requires explicit operator opt-in for any cross-origin access, which aligns the server with current CORS best practice and removes the CWE-942 condition.

## Adversarial review

Before submitting I tried to disprove this finding. The strongest counter-argument is that browsers refuse the `*` + `Allow-Credentials: true` combination, and every endpoint requires HTTP Basic auth, so the original configuration didn't actually permit credentialed cross-origin reads in a modern browser. That's true, and it's why I'd characterise the practical severity as medium rather than high. It doesn't make the fix unnecessary though: the server still advertises a permissive policy, the protection depends entirely on the browser rejecting a malformed header combination, and any future endpoint that responds without requiring auth would be cross-origin readable by any site. Switching to an explicit allow-list is a small, defensive change that closes the CWE-942 condition at the server rather than relying on the client.

## Compatibility

- Default behaviour for users who only access the server from the same origin (the documented case) is unchanged.
- Users who need cross-origin access set `ALLOWED_ORIGINS="https://a.example,https://b.example"`. A startup warning makes the new requirement discoverable.

cc @lewiswigmore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened CORS handling to restrict cross-origin requests to a configurable whitelist instead of allowing all origins.
  * Startup warns when allowed-origins configuration is missing or empty.
  * Requests from non-whitelisted origins (including preflight OPTIONS) are rejected with HTTP 403.
  * CORS responses now include appropriate Vary/credential behavior and explicit allowed methods/headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->