### PR TITLE
add option to merge notes and highlights

### DIFF
--- a/src/constants/settingList.tsx
+++ b/src/constants/settingList.tsx
@@ -95,6 +95,12 @@ export const generalSettingList = [
     title: "Open url with built-in browser",
     propName: "isUseBuiltIn",
   },
+  {
+    isElectron: false,
+    title: "Merge Notes and Highlights",
+    desc: "Merge the notes and highlights sections in the sidebar into just Notes",
+    propName: "isMergeNotes",
+  },
 ];
 export const appearanceSettingList = [
   {

--- a/src/containers/lists/navList/component.tsx
+++ b/src/containers/lists/navList/component.tsx
@@ -88,11 +88,34 @@ class NavList extends React.Component<NavListProps, NavListState> {
     notes: Note[],
     highlights: Note[]
   ) {
+    const isMergeNotes =
+      ConfigService.getReaderConfig("isMergeNotes") === "yes";
+
     if (currentTab === "bookmarks") {
       this.setState({
         currentData: bookmarks
           .filter((item) => item.bookKey === currentBook.key)
           .reverse(),
+      });
+    } else if (currentTab === "notes" && isMergeNotes) {
+      let noteList = notes.filter((item) => item.bookKey === currentBook.key);
+      let highlightList = highlights.filter(
+        (item) => item.bookKey === currentBook.key
+      );
+      let combined = [...noteList, ...highlightList];
+      combined.sort(
+        (a: any, b: any) => Number(b.percentage) - Number(a.percentage)
+      );
+
+      let fullData: any[] = [];
+      for (let i = 0; i < combined.length; i++) {
+        let record = await DatabaseService.getRecord(combined[i].key, "notes");
+        if (record) {
+          fullData.push(record);
+        }
+      }
+      this.setState({
+        currentData: fullData,
       });
     } else if (currentTab === "notes") {
       let noteList = notes.filter((item) => item.bookKey === currentBook.key);

--- a/src/containers/lists/noteList/component.tsx
+++ b/src/containers/lists/noteList/component.tsx
@@ -7,6 +7,7 @@ import Empty from "../../emptyPage";
 import { Trans } from "react-i18next";
 import ConfigUtil from "../../../utils/file/configUtil";
 import BookUtil from "../../../utils/file/bookUtil";
+import { ConfigService } from "../../../assets/lib/kookit-extra-browser.min";
 import Note from "../../../models/Note";
 
 class NoteList extends React.Component<NoteListProps, NoteListState> {
@@ -19,20 +20,46 @@ class NoteList extends React.Component<NoteListProps, NoteListState> {
       cardList: [],
     };
   }
+  getDisplayList = (notes: Note[], highlights: Note[], tabMode: string) => {
+    const isMergeNotes =
+      ConfigService.getReaderConfig("isMergeNotes") === "yes";
+    if (tabMode === "note" && isMergeNotes) {
+      let merged = [...notes, ...highlights];
+      let noteSortCodeStr =
+        ConfigService.getReaderConfig("noteSortCode") ||
+        '{"sort":1,"order":2}';
+      let noteSortCode = JSON.parse(noteSortCodeStr);
+      let sortField = noteSortCode.sort === 1 ? "key" : "percentage";
+      let sortOrder = noteSortCode.order === 1 ? "ASC" : "DESC";
+
+      merged.sort((a: any, b: any) => {
+        let valA = Number(a[sortField]);
+        let valB = Number(b[sortField]);
+        if (sortOrder === "ASC") {
+          return valA - valB;
+        } else {
+          return valB - valA;
+        }
+      });
+      return merged;
+    }
+    return tabMode === "note" ? notes : highlights;
+  };
   async UNSAFE_componentWillMount() {
     this.props.handleFetchNotes();
 
     this.setState({
-      cardList:
-        this.props.tabMode === "note"
-          ? this.props.notes
-          : this.props.highlights,
+      cardList: this.getDisplayList(
+        this.props.notes,
+        this.props.highlights,
+        this.props.tabMode
+      ),
     });
   }
   async componentDidMount() {
     this.props.handleFetchNotes();
   }
-  async componentWillReceiveProps(
+  async UNSAFE_componentWillReceiveProps(
     nextProps: Readonly<NoteListProps>,
     nextContext: any
   ) {
@@ -41,11 +68,18 @@ class NoteList extends React.Component<NoteListProps, NoteListState> {
       nextProps.highlights !== this.props.highlights
     ) {
       this.handleNamesMap(
-        nextProps.tabMode === "note" ? nextProps.notes : nextProps.highlights
+        this.getDisplayList(
+          nextProps.notes,
+          nextProps.highlights,
+          nextProps.tabMode
+        )
       );
       this.setState({
-        cardList:
-          nextProps.tabMode === "note" ? nextProps.notes : nextProps.highlights,
+        cardList: this.getDisplayList(
+          nextProps.notes,
+          nextProps.highlights,
+          nextProps.tabMode
+        ),
       });
     }
   }
@@ -59,16 +93,23 @@ class NoteList extends React.Component<NoteListProps, NoteListState> {
     if (tag.length === 0) {
       this.setState({
         tag: [],
-        cardList:
-          this.props.tabMode === "note"
-            ? this.props.notes
-            : this.props.highlights,
+        cardList: this.getDisplayList(
+          this.props.notes,
+          this.props.highlights,
+          this.props.tabMode
+        ),
       });
       return;
     }
+    const isMergeNotes =
+      ConfigService.getReaderConfig("isMergeNotes") === "yes";
     let cardList = await ConfigUtil.getNoteWithTags(tag);
     cardList = cardList.filter((note) =>
-      this.props.tabMode === "note" ? note.notes !== "" : note.notes === ""
+      isMergeNotes && this.props.tabMode === "note"
+        ? true
+        : this.props.tabMode === "note"
+          ? note.notes !== ""
+          : note.notes === ""
     );
     this.setState({ tag, cardList });
   };
@@ -105,20 +146,25 @@ class NoteList extends React.Component<NoteListProps, NoteListState> {
                 name=""
                 className="lang-setting-dropdown"
                 onChange={async (event) => {
+                  const isMergeNotes =
+                    ConfigService.getReaderConfig("isMergeNotes") === "yes";
                   this.setState({
                     currentSelectedBook: event.target.value,
                     cardList: await ConfigUtil.getNotesByBookKeyAndTypeWithSort(
                       event.target.value,
-                      this.props.tabMode
+                      isMergeNotes && this.props.tabMode === "note"
+                        ? ""
+                        : this.props.tabMode
                     ),
                   });
                 }}
               >
                 {[
                   { value: "", label: this.props.t("Please select") },
-                  ...(this.props.tabMode === "note"
-                    ? this.props.notes
-                    : this.props.highlights
+                  ...this.getDisplayList(
+                    this.props.notes,
+                    this.props.highlights,
+                    this.props.tabMode
                   )
                     .map((note) => {
                       return {

--- a/src/containers/panels/navigationPanel/component.tsx
+++ b/src/containers/panels/navigationPanel/component.tsx
@@ -331,19 +331,21 @@ class NavigationPanel extends React.Component<
                 >
                   <Trans>Note</Trans>
                 </span>
-                <span
-                  className="book-bookmark-title"
-                  style={
-                    this.state.currentTab === "highlights"
-                      ? {}
-                      : { opacity: 0.5 }
-                  }
-                  onClick={() => {
-                    this.handleChangeTab("highlights");
-                  }}
-                >
-                  <Trans>Highlight</Trans>
-                </span>
+                {ConfigService.getReaderConfig("isMergeNotes") !== "yes" && (
+                  <span
+                    className="book-bookmark-title"
+                    style={
+                      this.state.currentTab === "highlights"
+                        ? {}
+                        : { opacity: 0.5 }
+                    }
+                    onClick={() => {
+                      this.handleChangeTab("highlights");
+                    }}
+                  >
+                    <Trans>Highlight</Trans>
+                  </span>
+                )}
               </div>
             </div>
             <div className="navigation-body-parent">

--- a/src/containers/settings/generalSetting/component.tsx
+++ b/src/containers/settings/generalSetting/component.tsx
@@ -56,6 +56,7 @@ class GeneralSetting extends React.Component<
         ConfigService.getReaderConfig("isDeleteOriginal") === "yes",
       isDisablePDFCover:
         ConfigService.getReaderConfig("isDisablePDFCover") === "yes",
+      isMergeNotes: ConfigService.getReaderConfig("isMergeNotes") === "yes",
       startupShelf: ConfigService.getReaderConfig("startupShelf") || "",
     };
   }

--- a/src/containers/settings/generalSetting/interface.tsx
+++ b/src/containers/settings/generalSetting/interface.tsx
@@ -49,5 +49,6 @@ export interface SettingInfoState {
   isDisablePDFCover: boolean;
   isHideShelfBook: boolean;
   isPreventAdd: boolean;
+  isMergeNotes: boolean;
   startupShelf: string;
 }

--- a/src/containers/sidebar/component.tsx
+++ b/src/containers/sidebar/component.tsx
@@ -87,7 +87,11 @@ class Sidebar extends React.Component<SidebarProps, SidebarState> {
   };
   render() {
     const renderSideMenu = () => {
-      return sideMenu.map((item) => {
+      const isMergeNotes =
+        ConfigService.getReaderConfig("isMergeNotes") === "yes";
+      return sideMenu
+        .filter((item) => !(isMergeNotes && item.mode === "highlight"))
+        .map((item) => {
         return (
           <li
             key={item.name}

--- a/src/utils/file/configUtil.ts
+++ b/src/utils/file/configUtil.ts
@@ -255,20 +255,20 @@ class ConfigUtil {
       let queryString = "";
       let data: any[] = [];
       if (type === "note" && bookKey) {
-        queryString = `SELECT key, bookKey, chapterIndex FROM notes WHERE bookKey = ? AND notes != '' ORDER BY ${sort} ${order}`;
+        queryString = `SELECT key, bookKey, chapterIndex, percentage FROM notes WHERE bookKey = ? AND notes != '' ORDER BY ${sort} ${order}`;
         data = [bookKey];
       } else if (type === "highlight" && bookKey) {
-        queryString = `SELECT key, bookKey, chapterIndex FROM notes WHERE bookKey = ? AND notes = '' ORDER BY ${sort} ${order}`;
+        queryString = `SELECT key, bookKey, chapterIndex, percentage FROM notes WHERE bookKey = ? AND notes = '' ORDER BY ${sort} ${order}`;
         data = [bookKey];
       } else if (type === "note" && !bookKey) {
-        queryString = `SELECT key, bookKey, chapterIndex FROM notes WHERE notes != '' ORDER BY ${sort} ${order}`;
+        queryString = `SELECT key, bookKey, chapterIndex, percentage FROM notes WHERE notes != '' ORDER BY ${sort} ${order}`;
       } else if (type === "highlight" && !bookKey) {
-        queryString = `SELECT key, bookKey, chapterIndex FROM notes WHERE notes = '' ORDER BY ${sort} ${order}`;
+        queryString = `SELECT key, bookKey, chapterIndex, percentage FROM notes WHERE notes = '' ORDER BY ${sort} ${order}`;
       } else if (!type && bookKey) {
-        queryString = `SELECT key, bookKey, chapterIndex FROM notes WHERE bookKey = ? ORDER BY ${sort} ${order}`;
+        queryString = `SELECT key, bookKey, chapterIndex, percentage FROM notes WHERE bookKey = ? ORDER BY ${sort} ${order}`;
         data = [bookKey];
       } else {
-        queryString = `SELECT key, bookKey, chapterIndex FROM notes ORDER BY ${sort} ${order}`;
+        queryString = `SELECT key, bookKey, chapterIndex, percentage FROM notes ORDER BY ${sort} ${order}`;
       }
       const { ipcRenderer } = window.require("electron");
       return await ipcRenderer.invoke("custom-database-command", {


### PR DESCRIPTION
I added a option in settings to merge the notes and highlights into just notes. I always have wanted to look at all my notes including highlights in one place so i added the option. The setting works in both the sidebar for the main app gallery and for the left sidebar in the reader itself. 

<!-- Note that we only accept pull request related to translations -->
<!-- 请注意，我们只接受翻译相关的 Pull Request -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Merge Notes and Highlights" setting (web app only) allowing notes and highlights to be combined into a single list with flexible sorting options.
  * The Highlight navigation tab automatically hides when this setting is enabled for a streamlined view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->