### PR TITLE
Make native title bar follow app skin

### DIFF
--- a/main.js
+++ b/main.js
@@ -522,6 +522,21 @@ const removePickerUtil = (config) => {
     pickerUtilCache[config.service] = null;
   }
 };
+const getNativeThemeSource = (appSkin) => {
+  if (appSkin === "night") {
+    return "dark";
+  }
+  if (appSkin === "light") {
+    return "light";
+  }
+  return "system";
+};
+const applyNativeThemeSource = (appSkin) => {
+  nativeTheme.themeSource = getNativeThemeSource(appSkin);
+  store.set("appSkin", appSkin || "system");
+  return nativeTheme.shouldUseDarkColors;
+};
+applyNativeThemeSource(store.get("appSkin"));
 // Simple encryption function
 const encrypt = (text, key) => {
   let result = "";
@@ -1626,7 +1641,13 @@ const createMainWin = () => {
     event.returnValue = __dirname;
   });
   ipcMain.on("system-color", (event, arg) => {
-    event.returnValue = nativeTheme.shouldUseDarkColors || false;
+    event.returnValue =
+      (nativeTheme.shouldUseDarkColorsForSystemIntegratedUI ??
+        nativeTheme.shouldUseDarkColors) ||
+      false;
+  });
+  ipcMain.handle("set-native-theme-source", (event, appSkin) => {
+    return applyNativeThemeSource(appSkin);
   });
   ipcMain.on("check-main-open", (event, arg) => {
     event.returnValue = mainWin ? true : false;

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ const {
   ipcMain,
   dialog,
   powerSaveBlocker,
-  nativeTheme,
+  nativeTheme: electronNativeTheme,
   protocol,
   screen,
   systemPreferences,
@@ -531,10 +531,22 @@ const getNativeThemeSource = (appSkin) => {
   }
   return "system";
 };
+const getNativeDarkColorStatus = () => {
+  if (
+    typeof electronNativeTheme.shouldUseDarkColorsForSystemIntegratedUI !==
+    "undefined"
+  ) {
+    return electronNativeTheme.shouldUseDarkColorsForSystemIntegratedUI;
+  }
+  return electronNativeTheme.shouldUseDarkColors;
+};
 const applyNativeThemeSource = (appSkin) => {
-  nativeTheme.themeSource = getNativeThemeSource(appSkin);
+  if (process.type !== "browser") {
+    return false;
+  }
+  electronNativeTheme.themeSource = getNativeThemeSource(appSkin);
   store.set("appSkin", appSkin || "system");
-  return nativeTheme.shouldUseDarkColors;
+  return getNativeDarkColorStatus();
 };
 applyNativeThemeSource(store.get("appSkin"));
 // Simple encryption function
@@ -1641,10 +1653,7 @@ const createMainWin = () => {
     event.returnValue = __dirname;
   });
   ipcMain.on("system-color", (event, arg) => {
-    event.returnValue =
-      (nativeTheme.shouldUseDarkColorsForSystemIntegratedUI ??
-        nativeTheme.shouldUseDarkColors) ||
-      false;
+    event.returnValue = getNativeDarkColorStatus() || false;
   });
   ipcMain.handle("set-native-theme-source", (event, appSkin) => {
     return applyNativeThemeSource(appSkin);

--- a/src/containers/settings/appearanceSetting/component.tsx
+++ b/src/containers/settings/appearanceSetting/component.tsx
@@ -17,7 +17,10 @@ import {
   vexComfirmAsync,
   parseColorInput,
 } from "../../../utils/common";
-import { applyCustomSystemCSS } from "../../../utils/reader/launchUtil";
+import {
+  applyCustomSystemCSS,
+  syncNativeThemeSource,
+} from "../../../utils/reader/launchUtil";
 
 class AppearanceSetting extends React.Component<
   SettingInfoProps,
@@ -86,18 +89,9 @@ class AppearanceSetting extends React.Component<
     this.handleRest(nextValue);
   };
 
-  syncNativeThemeSource = (skin: string) => {
-    if (!isElectron) {
-      return;
-    }
-    window
-      .require("electron")
-      .ipcRenderer.invoke("set-native-theme-source", skin || "system");
-  };
-
   changeSkin = (skin: string) => {
     ConfigService.setReaderConfig("appSkin", skin);
-    this.syncNativeThemeSource(skin);
+    syncNativeThemeSource(skin);
 
     if (
       skin === "night" ||

--- a/src/containers/settings/appearanceSetting/component.tsx
+++ b/src/containers/settings/appearanceSetting/component.tsx
@@ -86,8 +86,18 @@ class AppearanceSetting extends React.Component<
     this.handleRest(nextValue);
   };
 
+  syncNativeThemeSource = (skin: string) => {
+    if (!isElectron) {
+      return;
+    }
+    window
+      .require("electron")
+      .ipcRenderer.invoke("set-native-theme-source", skin || "system");
+  };
+
   changeSkin = (skin: string) => {
     ConfigService.setReaderConfig("appSkin", skin);
+    this.syncNativeThemeSource(skin);
 
     if (
       skin === "night" ||

--- a/src/utils/reader/launchUtil.ts
+++ b/src/utils/reader/launchUtil.ts
@@ -9,7 +9,7 @@ import { ConfigService } from "../../assets/lib/kookit-extra-browser.min";
 import packageJson from "../../../package.json";
 import BackgroundUtil from "../file/backgroundUtil";
 
-const syncNativeThemeSource = (appSkin: string) => {
+export const syncNativeThemeSource = (appSkin: string) => {
   if (!isElectron) {
     return;
   }

--- a/src/utils/reader/launchUtil.ts
+++ b/src/utils/reader/launchUtil.ts
@@ -8,6 +8,15 @@ import {
 import { ConfigService } from "../../assets/lib/kookit-extra-browser.min";
 import packageJson from "../../../package.json";
 import BackgroundUtil from "../file/backgroundUtil";
+
+const syncNativeThemeSource = (appSkin: string) => {
+  if (!isElectron) {
+    return;
+  }
+  const { ipcRenderer } = window.require("electron");
+  ipcRenderer.invoke("set-native-theme-source", appSkin || "system");
+};
+
 export const initTheme = () => {
   const style = document.createElement("link");
   style.rel = "stylesheet";
@@ -34,6 +43,7 @@ export const initTheme = () => {
     if (isNight) {
     }
   }
+  syncNativeThemeSource(ConfigService.getReaderConfig("appSkin"));
 
   if (
     ConfigService.getReaderConfig("appSkin") === "night" ||


### PR DESCRIPTION
Fixes #1031

## What changed
- Map Koodo's app skin setting to Electron's nativeTheme.themeSource so the Windows native title bar follows light, dark, and system modes.
- Apply the cached app skin before the first window is created to reduce title bar flash on startup.
- Sync the native theme immediately when the Appearance setting changes.
- Keep system-color based on the OS/system-integrated dark preference so System mode still reflects the real OS setting.

## Validation
- node --check main.js
- git diff --cached --check
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate dark mode detection via tighter integration with the OS theme for truer color rendering.
  * Theme changes in app settings now synchronize immediately with the system/native theme for consistent appearance.
  * App initializes with the chosen theme sooner, so styles (dark/light) are applied more reliably on startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koodo-reader/koodo-reader/pull/1611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->