### PR TITLE
feat: add jump-to-furthest-read-page button in reader header

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -873,7 +873,6 @@
   "Voice type": "Voice type",
   "System voice": "System voice",
   "Purchase the code": "Purchase the code",
-
   "Please upgrade to Pro to use this feature": "Please upgrade to Pro to use this feature",
   "Query redemption code": "Query redemption code",
   "Custom voice": "Custom voice",
@@ -971,5 +970,6 @@
   "Show number of books in each shelf": "Show number of books in each shelf",
   "Custom AI Translation": "Custom AI Translation",
   "Custom AI Dictionary": "Custom AI Dictionary",
-  "Custom AI Assistance": "Custom AI Assistance"
+  "Custom AI Assistance": "Custom AI Assistance",
+  "Jump to furthest read page": "Jump to furthest read page"
 }

--- a/src/assets/locales/zh-CN.json
+++ b/src/assets/locales/zh-CN.json
@@ -1106,5 +1106,6 @@
   "Get more results": "获取更多结果",
   "Validation successful": "验证成功",
   "Validation failed": "验证失败",
-  "Please configure the KOReader sync server first": "请先配置 KOReader 同步服务器"
+  "Please configure the KOReader sync server first": "请先配置 KOReader 同步服务器",
+  "Jump to furthest read page": "跳转到最远阅读位置"
 }

--- a/src/assets/locales/zh-MO.json
+++ b/src/assets/locales/zh-MO.json
@@ -856,7 +856,6 @@
   "Voice type": "Voice type",
   "System voice": "System voice",
   "Purchase the code": "Purchase the code",
-
   "Please upgrade to Pro to use this feature": "Please upgrade to Pro to use this feature",
   "Query redemption code": "Query redemption code",
   "Custom voice": "Custom voice",
@@ -954,5 +953,6 @@
   "Show number of books in each shelf": "顯示每個書架中的圖書數量",
   "Custom AI Translation": "Custom AI Translation",
   "Custom AI Dictionary": "Custom AI Dictionary",
-  "Custom AI Assistance": "Custom AI Assistance"
+  "Custom AI Assistance": "Custom AI Assistance",
+  "Jump to furthest read page": "跳轉到最遠閱讀位置"
 }

--- a/src/assets/locales/zh-TW.json
+++ b/src/assets/locales/zh-TW.json
@@ -856,7 +856,6 @@
   "Voice type": "Voice type",
   "System voice": "System voice",
   "Purchase the code": "Purchase the code",
-
   "Please upgrade to Pro to use this feature": "Please upgrade to Pro to use this feature",
   "Query redemption code": "Query redemption code",
   "Custom voice": "Custom voice",
@@ -954,5 +953,6 @@
   "Show number of books in each shelf": "顯示每個書架中的圖書數量",
   "Custom AI Translation": "Custom AI Translation",
   "Custom AI Dictionary": "Custom AI Dictionary",
-  "Custom AI Assistance": "Custom AI Assistance"
+  "Custom AI Assistance": "Custom AI Assistance",
+  "Jump to furthest read page": "跳轉到最遠閱讀位置"
 }

--- a/src/containers/pageWidget/component.tsx
+++ b/src/containers/pageWidget/component.tsx
@@ -9,6 +9,10 @@ import { Trans } from "react-i18next";
 import { getBatchTrans, getWordDefinitions } from "../../utils/request/reader";
 import { detectLocalLanguage } from "../../utils/common";
 import toast from "react-hot-toast";
+import {
+  getFurthestLocation,
+  recordFurthestLocation,
+} from "../../utils/reader/furthestLocationUtil";
 class PageWidget extends React.Component<PageWidgetProps, PageWidgetState> {
   isFirst: Boolean;
   timeInterval: any;
@@ -22,6 +26,7 @@ class PageWidget extends React.Component<PageWidgetProps, PageWidgetState> {
       nextPage: 0,
       currentTime: this.getFormattedTime(),
       percentage: "",
+      showFurthest: false,
       ignoreNextPageChange: false,
     };
     this.isFirst = true;
@@ -156,6 +161,7 @@ class PageWidget extends React.Component<PageWidgetProps, PageWidgetState> {
     if (!pageInfo) {
       return;
     }
+    this.handleFurthest(rendition);
     if (
       this.props.currentBook.format === "PDF" &&
       !ConfigService.getAllListConfig("convertPDFBooks").includes(
@@ -179,6 +185,38 @@ class PageWidget extends React.Component<PageWidgetProps, PageWidgetState> {
       percentage: pageInfo.percentage,
     });
   }
+  handleFurthest = (rendition) => {
+    let position = rendition.getPosition();
+    recordFurthestLocation(this.props.currentBook.key, position);
+    let furthest = getFurthestLocation(this.props.currentBook.key);
+    // Compare against the same percentage source we just recorded. The small
+    // tolerance absorbs cross-session pagination drift: a furthest mark stored
+    // in a previous session can be marginally ahead of the freshly computed
+    // reopen position, which would otherwise show the button even when we are
+    // already at the furthest point.
+    let current = parseFloat((position && position.percentage) || "0");
+    this.setState({
+      showFurthest:
+        !!furthest &&
+        parseFloat(furthest.percentage as string) - current > 0.001,
+    });
+  };
+  handleJumpToFurthest = async () => {
+    let furthest = getFurthestLocation(this.props.currentBook.key);
+    if (!furthest || !this.props.htmlBook) return;
+    this.setState({ ignoreNextPageChange: true });
+    await this.props.htmlBook.rendition.goToPosition(
+      JSON.stringify({
+        text: furthest.text,
+        chapterTitle: furthest.chapterTitle,
+        chapterDocIndex: furthest.chapterDocIndex,
+        chapterHref: furthest.chapterHref,
+        count: furthest.hasOwnProperty("cfi") ? "ignore" : furthest.count,
+        percentage: furthest.percentage,
+        cfi: furthest.cfi,
+      })
+    );
+  };
 
   render() {
     return (
@@ -238,18 +276,6 @@ class PageWidget extends React.Component<PageWidgetProps, PageWidgetState> {
                   {this.props.currentBook.name}
                 </p>
               )}
-            {!this.props.isHideHeader && (
-              <>
-                <span className="footer-time">
-                  {this.state.currentTime}
-                  {this.state.percentage
-                    ? "  " +
-                      (parseFloat(this.state.percentage) * 100).toFixed(2) +
-                      "%"
-                    : ""}
-                </span>
-              </>
-            )}
           </div>
           <div className="footer-container">
             {!this.props.isHideFooter && this.state.prevPage > 0 && (
@@ -315,6 +341,29 @@ class PageWidget extends React.Component<PageWidgetProps, PageWidgetState> {
             </>
           )}
         </div>
+        {!this.props.isHideHeader && (
+          <div className="reading-status-bar">
+            <span className="footer-time">
+              {this.state.currentTime}
+              {this.state.percentage
+                ? "  " +
+                  (parseFloat(this.state.percentage) * 100).toFixed(2) +
+                  "%"
+                : ""}
+            </span>
+            {this.state.showFurthest && (
+              <span
+                className="furthest-read-button"
+                title={this.props.t("Jump to furthest read page")}
+                onClick={() => {
+                  this.handleJumpToFurthest();
+                }}
+              >
+                <span className="icon-pin"></span>
+              </span>
+            )}
+          </div>
+        )}
         {this.props.jumpPosition && (
           <div className="jump-return-button-container">
             <button

--- a/src/containers/pageWidget/interface.tsx
+++ b/src/containers/pageWidget/interface.tsx
@@ -27,5 +27,6 @@ export interface PageWidgetState {
   nextPage: number;
   currentTime: string;
   percentage: string;
+  showFurthest: boolean;
   ignoreNextPageChange: boolean;
 }

--- a/src/containers/pageWidget/pageWidget.css
+++ b/src/containers/pageWidget/pageWidget.css
@@ -40,13 +40,35 @@
   opacity: 0.3;
   float: left;
 }
-.footer-time {
-  letter-spacing: 0.5px;
+.reading-status-bar {
   position: absolute;
   top: 6px;
   left: 20px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+}
+.footer-time {
+  letter-spacing: 0.5px;
   font-size: 13px;
   opacity: 0.5;
+}
+.furthest-read-button {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  cursor: pointer;
+  opacity: 0.5;
+  pointer-events: all;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.furthest-read-button:hover {
+  opacity: 1;
+}
+.furthest-read-button .icon-pin {
+  font-size: 15px;
 }
 .bookmark {
   height: 40px;

--- a/src/utils/reader/furthestLocationUtil.ts
+++ b/src/utils/reader/furthestLocationUtil.ts
@@ -1,0 +1,47 @@
+import { ConfigService } from "../../assets/lib/kookit-extra-browser.min";
+
+// A reading position as produced by rendition.getPosition() / stored as
+// "recordLocation". We only rely on `percentage` here, but keep the rest so the
+// stored furthest location can be replayed through rendition.goToPosition().
+export interface BookLocation {
+  text?: string;
+  count?: string | number;
+  chapterTitle?: string;
+  chapterDocIndex?: string | number;
+  chapterHref?: string;
+  percentage?: string;
+  cfi?: string;
+  page?: string;
+  xpath?: string;
+  [key: string]: any;
+}
+
+const FURTHEST_LOCATION_KEY = "furthestLocation";
+
+const toPercentage = (location: BookLocation | null | undefined): number => {
+  if (!location || !location.percentage) return 0;
+  const value = parseFloat(location.percentage);
+  return isNaN(value) ? 0 : value;
+};
+
+// Persist `location` as the furthest-read position for a book, but only when it
+// is further along than what we have already recorded.
+export const recordFurthestLocation = (
+  bookKey: string,
+  location: BookLocation
+) => {
+  if (!bookKey || !location || !location.percentage) return;
+  const furthest = getFurthestLocation(bookKey);
+  if (toPercentage(location) > toPercentage(furthest)) {
+    ConfigService.setObjectConfig(bookKey, location, FURTHEST_LOCATION_KEY);
+  }
+};
+
+export const getFurthestLocation = (bookKey: string): BookLocation | null => {
+  const location = ConfigService.getObjectConfig(
+    bookKey,
+    FURTHEST_LOCATION_KEY,
+    {}
+  );
+  return location && location.percentage ? location : null;
+};


### PR DESCRIPTION
Track the furthest-read position per book and surface a button next to the time/percentage indicator to jump back to it instantly, useful after navigating backward to check a highlight or reference.

- Add furthestLocationUtil to persist the high-water-mark position (only advancing when the current percentage exceeds the stored one)
- Record and read the furthest location in PageWidget on page change
- Show a themed pin button only when the furthest mark is ahead of the current position (with a small tolerance to absorb cross-session pagination drift)
- Add "Jump to furthest read page" translation (en, zh-CN, zh-TW, zh-MO)

## Description

<!-- Note that we only accept pull request related to translations -->
<!-- 请注意，我们只接受翻译相关的 Pull Request -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "jump to furthest read page" functionality, allowing users to quickly navigate to their most advanced reading position in a book via a new button in the reading status bar.

* **Localization**
  * Added translations for the new feature across English, Simplified Chinese, Cantonese, and Traditional Chinese locales.

* **UI/Style Updates**
  * Updated reading status bar styling to accommodate the new furthest read button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->