### PR TITLE
docs: add Turkish (Türkçe) README translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="left">
 
 [简体中文](https://github.com/koodo-reader/koodo-reader/blob/master/README_cn.md) | [हिंदी](https://github.com/koodo-reader/koodo-reader/blob/master/README_hi.md)
-|[Português](https://github.com/koodo-reader/koodo-reader/blob/master/README_pt.md) | [Indonesian](https://github.com/koodo-reader/koodo-reader/blob/master/README_id.md) | English
+|[Português](https://github.com/koodo-reader/koodo-reader/blob/master/README_pt.md) | [Indonesian](https://github.com/koodo-reader/koodo-reader/blob/master/README_id.md) | English | [Türkçe](https://github.com/koodo-reader/koodo-reader/blob/master/README_tr.md)
 
 </div>
 

--- a/README_tr.md
+++ b/README_tr.md
@@ -1,0 +1,225 @@
+<div align="left">
+
+[简体中文](https://github.com/koodo-reader/koodo-reader/blob/master/README_cn.md) | [हिंदी](https://github.com/koodo-reader/koodo-reader/blob/master/README_hi.md) | [Português](https://github.com/koodo-reader/koodo-reader/blob/master/README_pt.md) | [Indonesian](https://github.com/koodo-reader/koodo-reader/blob/master/README_id.md) | [English](https://github.com/koodo-reader/koodo-reader/blob/master/README.md) | Türkçe
+
+</div>
+
+<div align="center" >
+  <img src="https://dl.koodoreader.com/screenshots/logo.png" width="96px" height="96px"/>
+</div>
+
+<h1 align="center">
+  Koodo Reader
+</h1>
+
+<h3 align="center">
+  Platformlar arası bir e-kitap okuyucu
+</h3>
+<div align="center">
+
+[İndir](https://koodoreader.com/en) | [Önizleme](https://web.koodoreader.com) | [Yol Haritası](https://koodoreader.com/en/roadmap) | [Belgeler](https://koodoreader.com/en/document) | [Eklentiler](https://koodoreader.com/en/plugin)
+
+</div>
+
+## Önizleme
+
+<div align="center">
+  <br/>
+  <br/>
+  <img src="https://dl.koodoreader.com/screenshots/7.png" width="800px">
+  <br/>
+  <br/>
+  <img src="https://dl.koodoreader.com/screenshots/8.png" width="800px">
+  <br/>
+  <br/>
+</div>
+
+## Özellikler
+
+- Biçim desteği:
+  - EPUB (**.epub**)
+  - PDF (**.pdf**)
+  - DRM içermeyen Mobipocket (**.mobi**) ve Kindle (**.azw3**, **.azw**)
+  - Düz metin (**.txt**)
+  - FictionBook (**.fb2**)
+  - Çizgi roman arşivi (**.cbr**, **.cbz**, **.cbt**, **.cb7**)
+  - Zengin metin (**.md**, **.docx**)
+  - HyperText (**.html**, **.xml**, **.xhtml**, **.mhtml**, **.htm**)
+- Platform desteği: **Windows**, **macOS**, **Linux**, **Android**, **iOS** ve **Web**
+- Verilerinizi **OneDrive**, **Google Drive**, **Dropbox**, **iCloud**, **MEGA**, **pCloud**, **Yandex Disk**, **Box**, **FTP**, **SFTP**, **WebDAV**, **SMB** veya **Nesne Depolama** ile eşitleyin ve yedekleyin
+- Kitaplarınızı **OneDrive**, **Google Drive**, **MEGA**, **Yandex Disk**, **Box**, **FTP**, **SFTP**, **WebDAV**, **SMB** veya **Nesne Depolama**'dan kolayca içe aktarın
+- Kendi özel yapay zekâ modelinizi kullanarak Yapay Zekâ Çevirisi, Yapay Zekâ Sözlüğü, Yapay Zekâ Özetleme ve Yapay Zekâ Ansiklopedisi özelliklerini çalıştırın
+- Okuma ilerlemesini **KOReader** ile eşitleyin
+- Notları ve vurguları **Readwise**, **Notion**, **Obsidian**, **Joplin** ve daha fazlasına eşitleyin
+- Yerel MDX sözlük araması desteği
+- Kelimeleri otomatik olarak **Anki** ve **Eudic**'e eşitleyin
+- Kitaplığınızı parola, PIN, Windows Hello, Touch ID ve daha fazlasıyla koruyun
+- Tüm kitapları tek tıkla dışa aktarın
+- Notları ve vurguları tek tıkla dışa aktarın; **CSV**, **Markdown**, **HTML**, **TXT** ve **PDF** desteklenir
+- Gizlilik öncelikli tasarım: izleme hizmeti yok, okuma verilerinizin veya kişisel bilgilerinizin proaktif olarak yüklenmesi yok
+- **OPDS** protokolünü destekler ve kitaplığınızı bir **OPDS** akışı olarak paylaşın
+- Web'deki her şeyi kitaplığınıza kaydetmek için tarayıcı uzantısı desteği
+- Çeviri, sözlük ve metin okuma için yerleşik 50'den fazla eklenti; özel eklenti desteğiyle birlikte
+- Dikey düzen kitap desteği
+- Okuma istatistikleri desteği
+- Yerleşik **Paddle** ve **Tesseract** OCR motorları
+- Kitaplık anlık görüntüleri ve sürüm denetimi desteği
+- Tek sütun, iki sütun veya sürekli kaydırma düzenleri
+- Metin okuma, çeviri, sözlük, dokunmatik ekran desteği ve toplu içe aktarma
+- Kitaplarınıza yer imleri, notlar ve vurgular ekleyin
+- Yazı tipi boyutunu, yazı tipi ailesini, satır aralığını, paragraf aralığını, arka plan rengini, metin rengini, kenar boşluklarını ve parlaklığı ayarlayın
+- Gece modu ve tema rengi
+- Metin vurgulama, altı çizme, kalınlaştırma, italik ve gölge
+
+## Kurulum
+
+### Masaüstü sürümü: [İndir](https://koodoreader.com/en/download)
+
+### Web sürümü：[Ziyaret et](https://web.koodoreader.com)
+
+### Android sürümü：[İndir](https://koodoreader.com/en/download)
+
+### iOS sürümü：[İndir](https://koodoreader.com/en/download)
+
+### Tarayıcı uzantısı：[İndir](https://www.koodoreader.com/en/use-extension)
+
+### Scoop ile kurulum:
+
+```shell
+scoop bucket add extras
+scoop install extras/koodo-reader
+```
+
+### Homebrew ile kurulum:
+
+```shell
+brew install --cask koodo-reader
+```
+
+### Docker ile kurulum:
+
+[Kurulum Kılavuzu](https://koodoreader.com/en/deploy-docker)
+
+## Ekran Görüntüleri
+
+<div align="center">
+  <b>Kitap listesi</b>
+  <br/>
+  <br/>
+  <kbd><img src="https://dl.koodoreader.com/screenshots/1.png" width="800px"></kbd>
+  <br/>
+  <br/>
+  <b>Kitap görünümü</b>
+  <br/>
+  <br/>
+  <kbd><img src="https://dl.koodoreader.com/screenshots/5.png" width="800px"></kbd>
+  <br/>
+  <br/>
+  <b>Liste modu</b>
+  <br/>
+  <br/>
+  <kbd><img src="https://dl.koodoreader.com/screenshots/2.png" width="800px"></kbd>
+  <br/>
+  <br/>
+  <b>Kapak modu</b>
+  <br/>
+  <br/>
+  <kbd><img src="https://dl.koodoreader.com/screenshots/3.png" width="800px"></kbd>
+  <br/>
+  <br/>
+  <b>Okuyucu menüsü</b>
+  <br/>
+  <br/>
+  <kbd><img src="https://dl.koodoreader.com/screenshots/6.png" width="800px"></kbd>
+  <br/>
+  <br/>
+  <b>Karanlık mod</b>
+  <br/>
+  <br/>
+  <kbd><img src="https://dl.koodoreader.com/screenshots/4.png" width="800px"></kbd>
+  <br/>
+</div>
+
+## Geliştirme
+
+yarn ve git'in kurulu olduğundan emin olun
+
+1. Depoyu indirin
+
+   ```
+   git clone https://github.com/koodo-reader/koodo-reader.git
+   ```
+
+2. Masaüstü moduna geçin
+
+   ```
+   yarn
+   yarn dev
+   ```
+
+3. Web moduna geçin
+
+   ```
+   yarn
+   yarn start
+   ```
+
+## Çeviri
+
+### Mevcut bir dili düzenleme
+
+1. Aşağıdaki listeden hedef dilinizi seçin.
+
+2. Kaynak dosyayı incelemek için görüntüle düğmesine tıklayın. Çevrilmemiş terimler her dosyanın en altında listelenir.
+
+3. Terimleri, verilen İngilizce referansa göre hedef dilinize çevirin.
+
+4. Çevirinizin miktarına bağlı olarak çeviri dosyasını ya da yalnızca çeviri parçalarını [bu bağlantıya](https://github.com/koodo-reader/koodo-reader/issues/new?assignees=&labels=submit+translation&projects=&template=submit_translation.yml) gönderin. Pull request de memnuniyetle karşılanır.
+
+| Dil (A-Z)       | Kod   | Görüntüle                               |
+| --------------- | ----- | --------------------------------------- |
+| Almanca         | de    | [Görüntüle](./src/assets/locales/de.json)    |
+| Amharca         | am    | [Görüntüle](./src/assets/locales/am.json)    |
+| Arapça          | ar    | [Görüntüle](./src/assets/locales/ar.json)    |
+| Bengalce        | bn    | [Görüntüle](./src/assets/locales/bn.json)    |
+| Bulgarca        | bg    | [Görüntüle](./src/assets/locales/bg.json)    |
+| Çekçe           | cs    | [Görüntüle](./src/assets/locales/cs.json)    |
+| Çince (CN)      | zh-CN | [Görüntüle](./src/assets/locales/zh-CN.json) |
+| Çince (MO)      | zh-MO | [Görüntüle](./src/assets/locales/zh-MO.json) |
+| Çince (TW)      | zh-TW | [Görüntüle](./src/assets/locales/zh-TW.json) |
+| Danca           | da    | [Görüntüle](./src/assets/locales/da.json)    |
+| Endonezce       | id    | [Görüntüle](./src/assets/locales/id.json)    |
+| Ermenice        | hy    | [Görüntüle](./src/assets/locales/hy.json)    |
+| Farsça          | fa    | [Görüntüle](./src/assets/locales/fa.json)    |
+| Fince           | fi    | [Görüntüle](./src/assets/locales/fi.json)    |
+| Fransızca       | fr    | [Görüntüle](./src/assets/locales/fr.json)    |
+| Hintçe          | hi    | [Görüntüle](./src/assets/locales/hi.json)    |
+| İngilizce       | en    | [Görüntüle](./src/assets/locales/en.json)    |
+| İrlandaca       | ga    | [Görüntüle](./src/assets/locales/ga.json)    |
+| İspanyolca      | es    | [Görüntüle](./src/assets/locales/es.json)    |
+| İsveççe         | sv    | [Görüntüle](./src/assets/locales/sv.json)    |
+| İtalyanca       | it    | [Görüntüle](./src/assets/locales/it.json)    |
+| İnterlingue     | ie    | [Görüntüle](./src/assets/locales/ie.json)    |
+| Japonca         | ja    | [Görüntüle](./src/assets/locales/ja.json)    |
+| Korece          | ko    | [Görüntüle](./src/assets/locales/ko.json)    |
+| Lehçe           | pl    | [Görüntüle](./src/assets/locales/pl.json)    |
+| Macarca         | hu    | [Görüntüle](./src/assets/locales/hu.json)    |
+| Portekizce      | pt    | [Görüntüle](./src/assets/locales/pt.json)    |
+| Portekizce (BR) | pt-BR | [Görüntüle](./src/assets/locales/pt-BR.json) |
+| Romence         | ro    | [Görüntüle](./src/assets/locales/ro.json)    |
+| Rusça           | ru    | [Görüntüle](./src/assets/locales/ru.json)    |
+| Slovence        | sl    | [Görüntüle](./src/assets/locales/sl.json)    |
+| Tagalogca       | tl    | [Görüntüle](./src/assets/locales/tl.json)    |
+| Tamilce         | ta    | [Görüntüle](./src/assets/locales/ta.json)    |
+| Tayca           | th    | [Görüntüle](./src/assets/locales/th.json)    |
+| Tibetçe         | bo    | [Görüntüle](./src/assets/locales/bo.json)    |
+| Türkçe          | tr    | [Görüntüle](./src/assets/locales/tr.json)    |
+| Ukraynaca       | uk    | [Görüntüle](./src/assets/locales/uk.json)    |
+| Vietnamca       | vi    | [Görüntüle](./src/assets/locales/vi.json)    |
+| Yunanca         | el    | [Görüntüle](./src/assets/locales/el.json)    |
+
+### Yeni dil ekleme
+
+1. Hedef dilinizi yukarıdaki listede bulamazsanız, İngilizce kaynak dosyasını [bu bağlantıdan](./src/assets/locales/en.json) indirin.
+
+2. Çeviriyi tamamladığınızda, kaynak dosyayı [bu bağlantıya](https://github.com/koodo-reader/koodo-reader/issues/new?assignees=&labels=submit+translation&projects=&template=submit_translation.yml) gönderin. Pull request de memnuniyetle karşılanır.


### PR DESCRIPTION
This PR adds a Turkish translation of the README.

## What's included
- **`README_tr.md`** — a complete Turkish (Türkçe) translation of the English README, following the same structure and formatting as the existing translated READMEs (`README_cn.md`, `README_pt.md`, `README_id.md`, `README_hi.md`).
- Added a **`Türkçe`** entry to the language bar at the top of the English `README.md`.

## Notes
- The language-switch bar inside `README_tr.md` links back to all existing translations and English.
- Turkish (`tr`) is already a supported UI locale, so a Turkish README is a natural fit for Turkish-speaking users.

Thanks for the great project! 🙌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a full Turkish README with localized overview, screenshots, feature highlights, installation steps, setup guidance, and translation instructions.
  * Updated the language selector in the main README to include Turkish alongside the existing language options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->