### PR TITLE
feat: add setting to hide already-read books from the list

### DIFF
--- a/src/constants/settingList.tsx
+++ b/src/constants/settingList.tsx
@@ -13,6 +13,12 @@ export const generalSettingList = [
   },
   {
     isElectron: false,
+    title: "Hide books already read",
+    desc: "Hide books that have been fully read, so they won't show up in the list",
+    propName: "isHideFinishedBook",
+  },
+  {
+    isElectron: false,
     title: "Delete book from shelf also deleting book itself",
     desc: "When deleting book from shelf, the book will be deleted as well",
     propName: "isDeleteShelfBook",

--- a/src/containers/lists/bookList/component.tsx
+++ b/src/containers/lists/bookList/component.tsx
@@ -34,6 +34,8 @@ class BookList extends React.Component<BookListProps, BookListState> {
   private scrollContainer: React.RefObject<HTMLUListElement>;
   private visibilityChangeHandler: ((event: Event) => void) | null = null;
   private resizeHandler: (() => void) | null = null;
+  private hideFinishedHandler: (() => void) | null = null;
+  private loadRequestId: number = 0;
 
   constructor(props: BookListProps) {
     super(props);
@@ -44,6 +46,8 @@ class BookList extends React.Component<BookListProps, BookListState> {
       ).length,
       isHideShelfBook:
         ConfigService.getReaderConfig("isHideShelfBook") === "yes",
+      isHideFinishedBook:
+        ConfigService.getReaderConfig("isHideFinishedBook") === "yes",
       displayedBooksCount: 24,
       isLoadingMore: false,
       fullBooksData: [], // 存储从数据库加载的完整书籍数据
@@ -56,6 +60,16 @@ class BookList extends React.Component<BookListProps, BookListState> {
   }
 
   async componentDidMount() {
+    this.hideFinishedHandler = () => {
+      this.setState(
+        {
+          isHideFinishedBook:
+            ConfigService.getReaderConfig("isHideFinishedBook") === "yes",
+        },
+        () => this.loadFullBooksData()
+      );
+    };
+    window.addEventListener("koodo-hide-finished-toggle", this.hideFinishedHandler);
     if (!this.props.books || !this.props.books[0]) {
       return <Redirect to="manager/empty" />;
     }
@@ -116,6 +130,8 @@ class BookList extends React.Component<BookListProps, BookListState> {
       const { ipcRenderer } = window.require("electron");
       ipcRenderer.removeAllListeners("reading-finished");
     }
+
+    window.removeEventListener("koodo-hide-finished-toggle", this.hideFinishedHandler);
   }
 
   componentDidUpdate(prevProps: BookListProps, prevState: BookListState) {
@@ -147,20 +163,19 @@ class BookList extends React.Component<BookListProps, BookListState> {
 
   // 从数据库加载完整的书籍数据
   loadFullBooksData = async () => {
+    const requestId = ++this.loadRequestId;
     const { books } = this.handleBooks();
     const displayedBooks = books.slice(0, this.state.displayedBooksCount);
 
     const fullBooksData: Book[] = [];
     for (let i = 0; i < displayedBooks.length; i++) {
-      const book = await DatabaseService.getRecord(
-        displayedBooks[i].key,
-        "books"
-      );
-      if (book) {
-        fullBooksData.push(book);
-      }
+      const book = await DatabaseService.getRecord(displayedBooks[i].key, "books");
+      if (book) fullBooksData.push(book);
     }
 
+    if (requestId !== this.loadRequestId) {
+      return; // a newer call has started since — discard this stale result
+    }
     this.setState({ fullBooksData });
   };
   handleFinishReading = async () => {
@@ -368,9 +383,9 @@ class BookList extends React.Component<BookListProps, BookListState> {
           ? this.handleShelf(this.props.books, this.props.shelfTitle)
           : bookMode === "favorite"
             ? this.handleKeyFilter(
-                this.props.books,
-                ConfigService.getAllListConfig("favoriteBooks")
-              )
+              this.props.books,
+              ConfigService.getAllListConfig("favoriteBooks")
+            )
             : bookMode === "hide"
               ? this.handleFilterShelfBook(this.props.books)
               : this.props.books;
@@ -379,6 +394,12 @@ class BookList extends React.Component<BookListProps, BookListState> {
         books,
         this.state.readingStatusFilter
       );
+    }
+    if (this.state.isHideFinishedBook) {
+      books = books.filter((book) => {
+        const record = ConfigService.getObjectConfig(book.key, "recordLocation", {});
+        return record.percentage !== "1";
+      });
     }
     const topBookKeys: string[] = ConfigService.getAllListConfig("topBooks");
     if (topBookKeys.length > 0) {

--- a/src/containers/lists/bookList/component.tsx
+++ b/src/containers/lists/bookList/component.tsx
@@ -395,7 +395,7 @@ class BookList extends React.Component<BookListProps, BookListState> {
         this.state.readingStatusFilter
       );
     }
-    if (this.state.isHideFinishedBook) {
+    if (this.state.isHideFinishedBook && (bookMode === "home" || bookMode === "hide")) {
       books = books.filter((book) => {
         const record = ConfigService.getObjectConfig(book.key, "recordLocation", {});
         return record.percentage !== "1";

--- a/src/containers/lists/bookList/interface.tsx
+++ b/src/containers/lists/bookList/interface.tsx
@@ -31,4 +31,5 @@ export interface BookListState {
   fullBooksData: BookModel[];
   cardScale: number;
   readingStatusFilter: string;
+  isHideFinishedBook: boolean;
 }

--- a/src/containers/settings/generalSetting/component.tsx
+++ b/src/containers/settings/generalSetting/component.tsx
@@ -35,6 +35,8 @@ class GeneralSetting extends React.Component<
         ConfigService.getReaderConfig("isDeleteShelfBook") === "yes",
       isHideShelfBook:
         ConfigService.getReaderConfig("isHideShelfBook") === "yes",
+      isHideFinishedBook:
+        ConfigService.getReaderConfig("isHideFinishedBook") === "yes",
       isPreventSleep: ConfigService.getReaderConfig("isPreventSleep") === "yes",
       isAlwaysOnTop: ConfigService.getReaderConfig("isAlwaysOnTop") === "yes",
       isAutoMaximizeWin:
@@ -137,6 +139,10 @@ class GeneralSetting extends React.Component<
                   case "isAlwaysOnTop":
                     this.handleAlwaysOnTop();
                     break;
+                  case "isHideFinishedBook":
+                    this.handleSetting("isHideFinishedBook");
+                    window.dispatchEvent(new CustomEvent("koodo-hide-finished-toggle"));
+                    break;
                   case "isAutoMaximizeWin":
                     this.handleMaximizeWin();
                     break;
@@ -158,13 +164,13 @@ class GeneralSetting extends React.Component<
                 style={
                   this.state[item.propName]
                     ? {
-                        transform: "translateX(20px)",
-                        transition: "transform 0.5s ease",
-                      }
+                      transform: "translateX(20px)",
+                      transition: "transform 0.5s ease",
+                    }
                     : {
-                        transform: "translateX(0px)",
-                        transition: "transform 0.5s ease",
-                      }
+                      transform: "translateX(0px)",
+                      transition: "transform 0.5s ease",
+                    }
                 }
               ></span>
             </span>

--- a/src/containers/settings/generalSetting/interface.tsx
+++ b/src/containers/settings/generalSetting/interface.tsx
@@ -48,6 +48,7 @@ export interface SettingInfoState {
   isDeleteOriginal: boolean;
   isDisablePDFCover: boolean;
   isHideShelfBook: boolean;
+  isHideFinishedBook: boolean;
   isPreventAdd: boolean;
   startupShelf: string;
 }


### PR DESCRIPTION
## What

Added a new General setting, **"Hide books already read"**, which hides
books that have reached 100% reading progress from the home and list views.

## Why

Users with large libraries may prefer to focus on unread or in-progress
books without removing completed books from their library.

## Changes

- Added a new toggle under **Settings → General** (`isHideFinishedBook`)
- Applied filtering in `bookList`'s `handleBooks()`
- Reused the existing percentage-based "finished" logic from the reading-status filter
- Added the required localization strings to `en.json`

## Testing

- Verified the toggle appears in Settings
- Verified the setting persists across app restarts
- Confirmed completed books are hidden/shown correctly when toggling the option
- Confirmed no changes in:
  - Shelf view
  - Favorites view
  - Search results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Hide books already read” setting.
  * When enabled, finished books are hidden on relevant views and the preference persists.

* **Bug Fixes**
  * Improved book list refresh behavior to prevent outdated results from appearing during rapid updates.
  * Applied the finished-book filtering consistently when the new setting is turned on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->