### PR TITLE
fix(viewer): trigger highlight popup on mobile via selectionchange

### DIFF
--- a/src/containers/viewer/component.tsx
+++ b/src/containers/viewer/component.tsx
@@ -590,6 +590,30 @@ class Viewer extends React.Component<ViewerProps, ViewerState> {
         var rect = selection.getRangeAt(0).getBoundingClientRect();
         this.setState({ rect });
       });
+      doc.addEventListener(
+        "selectionchange",
+        _.debounce(() => {
+          if (
+            this.props.currentBook.format === "PDF" &&
+            !ConfigService.getAllListConfig("convertPDFBooks").includes(
+              this.props.currentBook.key
+            )
+          ) {
+            let iframe = doc.defaultView?.frameElement as HTMLIFrameElement | null;
+            let id = iframe?.getAttribute("id") || "";
+            let chapterDocIndex = id ? parseInt(id.split("-").reverse()[0]) : 0;
+            this.setState({ chapterDocIndex });
+          }
+
+          if (this.state.isDisablePopup) return;
+
+          let selection = doc!.getSelection();
+          if (!selection || selection.rangeCount === 0) return;
+
+          var rect = selection.getRangeAt(0).getBoundingClientRect();
+          this.setState({ rect });
+        }, 100)
+      );
     }
   };
   render() {


### PR DESCRIPTION
Adds a debounced selectionchange listener to each iframe document, complementing the existing mouseup/contextmenu handlers.

On touch devices where mouseup does not fire reliably after a text selection, this event ensures the highlight/annotation popup still appears.

- 100ms debounce avoids excessive re-renders during selection changes
- Respects the isDisablePopup flag
- Updates chapterDocIndex for non-converted PDFs, matching existing mouseup/contextmenu behavior

Fixes #39, fixes #1458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text selection behavior inside embedded reading views.
  * Selection updates now respond more reliably when you change the selected text, helping popups and selection-based actions appear in the right place.
  * Navigation tracking for selected content is now more consistent in supported books.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->