### PR TITLE
fix(downloading):Fix download progress exceeding 100% when downloadin…

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1096,29 +1096,37 @@ export const getPdfPassword = (book: Book) => {
 export const showDownloadProgress = (
   service: string,
   type: string,
-  bookSize: number
+  bookSize: number,
+  bookKey?: string
 ) => {
   if (bookSize === 0) {
     return setTimeout(() => {
       console.warn("Book size is 0, skipping download progress.");
     }, 1000);
   }
+
+  const toastId = bookKey ? `offline-book-${bookKey}` : "offline-book";
+  // 记录下载起始时 cloud-progress 的基线值，用增量估算当前书的进度
+  let baseline: number | null = null;
+
   let isFirst = true;
   let timer = setInterval(async () => {
     let downloadedSize = 0;
+    let progress = 0;
+
     if (isElectron) {
+      let tokenConfig = await getCloudConfig(service);
+      let config = {
+        ...tokenConfig,
+        service: service,
+        storagePath: getStorageLocation(),
+      };
+
       if (type === "cloud") {
-        let tokenConfig = await getCloudConfig(service);
-        let config = {
-          ...tokenConfig,
-          service: service,
-          storagePath: getStorageLocation(),
-        };
         downloadedSize = await window
           .require("electron")
           .ipcRenderer.invoke("cloud-progress", config);
       } else {
-        let tokenConfig = await getCloudConfig(service);
         downloadedSize = await window
           .require("electron")
           .ipcRenderer.invoke("picker-progress", {
@@ -1129,17 +1137,20 @@ export const showDownloadProgress = (
             storagePath: getStorageLocation(),
           });
       }
-      if (isFirst && downloadedSize > 0) {
-        downloadedSize = 0;
-        isFirst = false;
-      }
-      let progress = downloadedSize / bookSize;
-      toast.loading(
-        i18n.t("Downloading") + " (" + parseInt(progress * 100 + "") + "%)",
-        {
-          id: "offline-book",
+
+      // 增量修改，采用基线法和原方法作为备份，确保下载进度正确     
+      if (bookKey) {
+        if (baseline === null) {
+          baseline = downloadedSize;
         }
-      );
+        progress = Math.min(Math.max((downloadedSize - baseline) / bookSize, 0), 1);
+      } else {
+        if (isFirst && downloadedSize > 0) {
+          downloadedSize = 0;
+          isFirst = false;
+        }
+        progress = downloadedSize / bookSize;
+      }
     } else {
       if (type === "cloud") {
         let syncUtil = await SyncService.getSyncUtil();
@@ -1152,14 +1163,13 @@ export const showDownloadProgress = (
         downloadedSize = 0;
         isFirst = false;
       }
-      let progress = downloadedSize / bookSize;
-      toast.loading(
-        i18n.t("Downloading") + " (" + parseInt(progress * 100 + "") + "%)",
-        {
-          id: "offline-book",
-        }
-      );
+      progress = downloadedSize / bookSize;
     }
+    toast.loading(
+        i18n.t("Downloading") + " (" + parseInt(progress * 100 + "") + "%)",
+        { id: toastId }
+      );
+
   }, 500);
   return timer;
 };

--- a/src/utils/file/bookUtil.ts
+++ b/src/utils/file/bookUtil.ts
@@ -216,7 +216,7 @@ class BookUtil {
         return;
       }
       toast.loading(i18n.t("Downloading"), {
-        id: "offline-book",
+        id: "offline-book-" + book.key,
       });
       if (
         (await TokenService.getToken("is_authed")) === "yes" &&
@@ -225,11 +225,12 @@ class BookUtil {
         let timer = showDownloadProgress(
           ConfigService.getItem("defaultSyncOption") || "",
           "cloud",
-          book.size
+          book.size,
+          book.key
         );
         let result = await this.downloadBook(book.key, book.format);
         clearInterval(timer);
-        toast.dismiss("offline-book");
+        toast.dismiss("offline-book-" + book.key);
 
         let covers = await CoverUtil.getCloudCoverList();
         for (let cover of covers) {
@@ -240,17 +241,17 @@ class BookUtil {
 
         if (result) {
           toast.success(i18n.t("Download successful"), {
-            id: "offline-book",
+            id: "offline-book-" + book.key,
           });
         } else {
           let result = await this.downloadCacheBook(book.key);
           if (result) {
             toast.success(i18n.t("Download successful"), {
-              id: "offline-book",
+              id: "offline-book-" + book.key,
             });
           } else {
             toast.error(i18n.t("Download failed"), {
-              id: "offline-book",
+              id: "offline-book-" + book.key,
             });
             if (ConfigService.getItem("defaultSyncOption") === "adrive") {
               toast.error(
@@ -258,7 +259,7 @@ class BookUtil {
                   "Aliyun Drive imposes strict limits on concurrent downloads. It is recommended that you wait 10 seconds before attempting to download again."
                 ),
                 {
-                  id: "offline-book",
+                  id: "offline-book-" + book.key,
                 }
               );
             }
@@ -267,7 +268,7 @@ class BookUtil {
         }
       } else {
         toast.error(i18n.t("Book not exists"), {
-          id: "offline-book",
+          id: "offline-book-" + book.key,
         });
         return;
       }


### PR DESCRIPTION
…g multiple files from cloud simultaneously on Windows desktop

- While using a single SyncUtil, isolate download progress per book by assigning a unique toastId in showDownloadProgress.
- Adopt a baseline approach: use the first downloadedSize obtained from cloud-progress as the baseline for progress calculation.
- Extract tokenConfig and config from each if branch to avoid duplication.
- Make incremental changes; keep the original counting strategy to avoid unintended side effects.

## Description
使用windows和Android端的时候，发现多文件从云端同时下载进度不正确，且表现不一样。我未发现Android的代码和构建方法就仅修改Windows端的部分，通过yarn dev测试后确认各项环节正常。测试结果与问题如下：

  每个文件单独的toast，各自下载进度独立正常。

  但是我的电脑为**windows-amd64**，arm版构建失败，仅能确保**windows桌面**上正确，不能保证网页和arm版也正确。

  且可能因为轮询的原因，对小文件下载进度显示不全，比如显示到 _下载中（37%）_ ，然后就结束了。

个人环境：
系统：windows10

node 20.20.2

yarn 1.22.22

python 3.8.20

使用阿里云盘

## Description
During usage on both Windows desktop and Android sides, we observed that download progress for multiple files from the cloud is incorrect, and the behavior differs between the two platforms. Since I could not locate the Android source code or build setup, I only modified the Windows portion.

After testing locally with yarn dev, I confirmed that:

    Each file has its own independent toast notification, and their download progresses are isolated correctly.

    The overall functionality works as expected on my development environment.

However, please note the following limitations:

    My machine is Windows‑AMD64. The ARM build failed, so I can only guarantee correctness on Windows desktop; I cannot ensure that web or ARM versions will behave the same.

    Due to the polling mechanism, progress may not fully display for very small files. For example, it might show Downloading (37%) and then finish abruptly without reaching 100%.

My local environment:

    OS: Windows 10

    Node: 20.20.2

    Yarn: 1.22.22

    Python: 3.8.20

(The cloud storage service used for testing was Aliyun Drive.) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Download progress now tracks each book separately, so progress updates and toasts no longer overlap between different downloads.
  * Progress reporting is more accurate for ongoing downloads and now handles both desktop and non-desktop flows more consistently.
  * Download success and failure notifications now stay tied to the correct book.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->