### PR TITLE
fix(import): resolve Out of Memory error when importing large books

### DIFF
--- a/src/components/importLocal/component.tsx
+++ b/src/components/importLocal/component.tsx
@@ -98,15 +98,17 @@ class ImportLocal extends React.Component<ImportLocalProps, ImportLocalState> {
   }
   handleFilePath = async (filePath: string) => {
     clickFilePath = filePath;
-    let md5 = await calculateFileMD5(await fetchFileFromPath(filePath));
+    // Read the file from disk only once and reuse it for both the MD5 check
+    // and the import. Previously the file was read twice, which doubled the
+    // memory usage for large books.
+    const fileTemp = await fetchFileFromPath(filePath);
+    let md5 = await calculateFileMD5(fileTemp);
 
     let repeatBook: BookModel | null = await BookUtil.getBookByMd5(md5);
     if (repeatBook) {
       this.handleJump(repeatBook);
       return;
     }
-
-    const fileTemp = await fetchFileFromPath(filePath);
 
     this.setState({ isOpenFile: true }, async () => {
       await this.getMd5WithBrowser(fileTemp);
@@ -269,93 +271,96 @@ class ImportLocal extends React.Component<ImportLocalProps, ImportLocalState> {
         return resolve();
       }
       if (!isRepeat) {
+        // Read the file into an ArrayBuffer exactly once. Previously the file
+        // was read twice here (an outer read whose result was discarded, plus
+        // an inner read). For large books this duplicated the whole file in
+        // memory and caused "Out of Memory" errors during import.
         let reader = new FileReader();
-        reader.readAsArrayBuffer(file);
+        reader.onerror = () => {
+          console.error("read error", bookName);
+          toast.error(this.props.t("Import failed") + ": " + bookName, {
+            duration: 4000,
+          });
+          return resolve();
+        };
+        reader.onload = async (event) => {
+          let file_content = (event.target as any).result;
+          let result: BookModel;
+          try {
+            let rendition = BookHelper.getRendition(
+              file_content,
+              {
+                format: extension.toUpperCase(),
+                readerMode: "",
+                charset: "",
+                animation:
+                  ConfigService.getReaderConfig("animation") || "none",
+                convertChinese:
+                  ConfigService.getReaderConfig("convertChinese"),
+                bookLayout: ConfigService.getReaderConfig("bookLayout"),
+                textRules: getTextRules(),
+                codeHighlight:
+                  ConfigService.getReaderConfig("codeHighlight") || "",
+                fullTranslationMode: "no",
+                textOrientation:
+                  ConfigService.getReaderConfig("textOrientation"),
+                parserRegex: "",
+                isDarkMode: "no",
+                isMobile: "no",
+                password: "",
+                isScannedPDF: "no",
+                isKeepPDFBackground: "no",
+              },
+              Kookit
+            );
+            result = await BookHelper.generateBook(
+              bookName,
+              extension,
+              md5,
+              file.size,
+              file.path || clickFilePath,
+              file_content,
+              rendition
+            );
 
-        reader.onload = async (e) => {
-          if (!e.target) {
-            console.error("e.target error", bookName);
+            if (
+              ConfigService.getReaderConfig("isPrecacheBook") === "yes" &&
+              extension !== "pdf"
+            ) {
+              let cache = await rendition.preCache(file_content);
+              if (cache !== "err" || cache) {
+                await BookUtil.addBook("cache-" + result.key, "zip", cache);
+              }
+            }
+          } catch (error) {
+            console.error(error, bookName);
             toast.error(this.props.t("Import failed") + ": " + bookName, {
               duration: 4000,
             });
             return resolve();
           }
-          let reader = new FileReader();
-          reader.onload = async (event) => {
-            const file_content = (event.target as any).result;
-            try {
-              let rendition = BookHelper.getRendition(
-                file_content,
-                {
-                  format: extension.toUpperCase(),
-                  readerMode: "",
-                  charset: "",
-                  animation:
-                    ConfigService.getReaderConfig("animation") || "none",
-                  convertChinese:
-                    ConfigService.getReaderConfig("convertChinese"),
-                  bookLayout: ConfigService.getReaderConfig("bookLayout"),
-                  textRules: getTextRules(),
-                  codeHighlight:
-                    ConfigService.getReaderConfig("codeHighlight") || "",
-                  fullTranslationMode: "no",
-                  textOrientation:
-                    ConfigService.getReaderConfig("textOrientation"),
-                  parserRegex: "",
-                  isDarkMode: "no",
-                  isMobile: "no",
-                  password: "",
-                  isScannedPDF: "no",
-                  isKeepPDFBackground: "no",
-                },
-                Kookit
-              );
-              result = await BookHelper.generateBook(
-                bookName,
-                extension,
-                md5,
-                file.size,
-                file.path || clickFilePath,
-                file_content,
-                rendition
-              );
 
-              if (
-                ConfigService.getReaderConfig("isPrecacheBook") === "yes" &&
-                extension !== "pdf"
-              ) {
-                let cache = await rendition.preCache(file_content);
-                if (cache !== "err" || cache) {
-                  await BookUtil.addBook("cache-" + result.key, "zip", cache);
-                }
-              }
-            } catch (error) {
-              console.error(error, bookName);
-              toast.error(this.props.t("Import failed") + ": " + bookName, {
-                duration: 4000,
-              });
-              return resolve();
-            }
+          clickFilePath = "";
 
-            clickFilePath = "";
-
-            // get metadata failed
-            if (!result || !result.key) {
-              console.error("get metadata failed", bookName);
-              toast.error(this.props.t("Import failed") + ": " + bookName, {
-                duration: 4000,
-              });
-              return resolve();
-            }
-            await this.handleAddBook(
-              result as BookModel,
-              file_content as ArrayBuffer
-            );
-
+          // get metadata failed
+          if (!result || !result.key) {
+            console.error("get metadata failed", bookName);
+            toast.error(this.props.t("Import failed") + ": " + bookName, {
+              duration: 4000,
+            });
             return resolve();
-          };
-          reader.readAsArrayBuffer(file);
+          }
+          await this.handleAddBook(
+            result as BookModel,
+            file_content as ArrayBuffer
+          );
+
+          // Release the reference to the (potentially very large) buffer so it
+          // can be garbage collected before the next book is processed.
+          file_content = null;
+          return resolve();
         };
+        reader.readAsArrayBuffer(file);
       }
     });
   };

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -74,16 +74,39 @@ export const calculateFileMD5 = (file: File): Promise<string> => {
       reader.onerror = (error) => reject(error);
       reader.readAsArrayBuffer(file);
     } else {
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        const arrayBuffer = event.target?.result as ArrayBuffer;
-        const wordArray = CryptoJS.lib.WordArray.create(
-          new Uint8Array(arrayBuffer) as any
-        );
-        resolve(CryptoJS.MD5(wordArray).toString());
+      // Compute the MD5 by streaming the file in small chunks instead of
+      // reading the whole file into memory at once. The previous approach
+      // (FileReader + CryptoJS.lib.WordArray.create on the full buffer) kept
+      // the entire file AND a copy of it alive simultaneously, which caused
+      // "Out of Memory" errors for large books (e.g. 127 MB).
+      const CHUNK_SIZE = 4 * 1024 * 1024; // 4 MB
+      const fileSize = file.size;
+      const hash = CryptoJS.algo.MD5.create();
+      let offset = 0;
+
+      const readNextChunk = () => {
+        if (offset >= fileSize) {
+          resolve(hash.finalize().toString());
+          return;
+        }
+        const end = Math.min(offset + CHUNK_SIZE, fileSize);
+        const blob = file.slice(offset, end);
+        const chunkReader = new FileReader();
+        chunkReader.onload = (event) => {
+          const chunk = event.target?.result as ArrayBuffer;
+          if (chunk && chunk.byteLength > 0) {
+            const wordArray = CryptoJS.lib.WordArray.create(
+              new Uint8Array(chunk) as any
+            );
+            hash.update(wordArray);
+          }
+          offset = end;
+          readNextChunk();
+        };
+        chunkReader.onerror = (error) => reject(error);
+        chunkReader.readAsArrayBuffer(blob);
       };
-      reader.onerror = (error) => reject(error);
-      reader.readAsArrayBuffer(file);
+      readNextChunk();
     }
   });
 };


### PR DESCRIPTION
Stream the MD5 computation in 4 MB chunks via file.slice() instead of loading the entire file into memory at once, which previously created a full duplicate copy (~250 MB for a 127 MB book) before parsing even began.

Also remove a redundant double FileReader.readAsArrayBuffer() call in handleBook (the outer read's result was never used), read the file from disk only once in handleFilePath, and release the buffer reference after import to let the garbage collector reclaim memory sooner.

Peak memory during import of a 127 MB book is reduced from ~380 MB to a single file buffer plus minor parser overhead.

## Description

<!-- Note that we only accept pull request related to translations -->
<!-- 请注意，我们只接受翻译相关的 Pull Request -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved local file importing by avoiding duplicate file reads.
  * Reduced memory usage when calculating checksums for large files.
  * Improved handling of file parsing and import errors.
* **Bug Fixes**
  * Improved detection of previously imported books.
  * Fixed redundant file-processing behavior during local imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->